### PR TITLE
Improved reliability to BlockTextpromptAlertView

### DIFF
--- a/BlockAlertsDemo/ToAddToYourProjects/BlockAlertView.m
+++ b/BlockAlertsDemo/ToAddToYourProjects/BlockAlertView.m
@@ -285,7 +285,9 @@ static UIFont *buttonFont = nil;
                                               center.y -= kAlertViewBounce;
                                               _view.center = center;
                                           } 
-                                          completion:nil];
+                                          completion:^(BOOL finished) {
+                                              [[NSNotificationCenter defaultCenter] postNotificationName:@"AlertViewFinishedAnimations" object:nil];
+                                          }];
                      }];
     
     [self retain];

--- a/BlockAlertsDemo/ToAddToYourProjects/BlockTextPromptAlertView.m
+++ b/BlockAlertsDemo/ToAddToYourProjects/BlockTextPromptAlertView.m
@@ -83,12 +83,13 @@
     
     [super show];
     
-    [self.textField performSelector:@selector(becomeFirstResponder) withObject:nil afterDelay:0.5];
+    [[NSNotificationCenter defaultCenter] addObserver:textField selector:@selector(becomeFirstResponder) name:@"AlertViewFinishedAnimations" object:nil];
 }
 
 - (void)dismissWithClickedButtonIndex:(NSInteger)buttonIndex animated:(BOOL)animated {
     [super dismissWithClickedButtonIndex:buttonIndex animated:animated];
     
+    [[NSNotificationCenter defaultCenter] removeObserver:textField];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillShowNotification object:nil];
 }
 


### PR DESCRIPTION
When calling show to BlockTextpromptAlertView in some cases and
devices, the AlertView didn't go up and stood behind the keyboard. So
instead of using an NSTimer to trigger to the TextField
becomeFirstResponder, now it's done via NSNotificationCenter from the
animations completion block from the superclass BlockAlertView.
