### PR TITLE
Fixes an issue that appears when a block action causes another view to m...

### DIFF
--- a/BlockAlertsDemo/ToAddToYourProjects/BlockBackground.m
+++ b/BlockAlertsDemo/ToAddToYourProjects/BlockBackground.m
@@ -192,17 +192,21 @@ static BlockBackground *_sharedInstance = nil;
         [topView removeFromSuperview];
     }
     
-    if (self.subviews.count == 0)
+    self.hidden = YES;
+    [_previousKeyWindow makeKeyWindow];
+
+    //Remaining subviews added elsewhere should be handed off to the previous key window
+    if (self.subviews.count > 0)
     {
-        self.hidden = YES;
-        [_previousKeyWindow makeKeyWindow];
-        [_previousKeyWindow release];
-        _previousKeyWindow = nil;
+        for (UIView* aView in self.subviews) {
+            [aView removeFromSuperview];
+            [_previousKeyWindow addSubview:aView];
+        }
+        ((UIView*)[_previousKeyWindow.subviews lastObject]).userInteractionEnabled = YES;
     }
-    else
-    {
-        ((UIView*)[self.subviews lastObject]).userInteractionEnabled = YES;
-    }
+
+    [_previousKeyWindow release];
+    _previousKeyWindow = nil;
 }
 
 - (void)drawRect:(CGRect)rect 


### PR DESCRIPTION
...ake itself a subview of the UIApplication.keywindow.  This bug was discovered when the Facebook API was called from a block action, displaying one of the custom FBDialog class windows.  The FB API puts this view into the keywindow.  When the FBDialog was dismissed, the BlockBackground remained, and made the underlying content unresponsive.  This fix moves additional views in the BlockBackground view hierarchy out of itself when the time comes to give up keywindow status,  and into the restored keywindow.

This fix may mess with fixes intended to handle multiple sheets to be called within one another and should be tested for this condition.
